### PR TITLE
Add language param to Generate API

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -60,7 +60,7 @@ type GenerateOptions struct {
 	// text.
 	ReturnLikelihoods string `json:"return_likelihoods,omitempty"`
 
-	//optional - One of en|pt|sp|fr|de to specify the language of the prompt. By default, the language is English.
+	// optional - One of en|pt|sp|fr|de to specify the language of the prompt. By default, the language is English.
 	Language string `json:"language,omitempty"`
 }
 

--- a/generate.go
+++ b/generate.go
@@ -59,6 +59,9 @@ type GenerateOptions struct {
 	// text. If ALL is selected, the token likelihoods will be provided both for the prompt and the generated
 	// text.
 	ReturnLikelihoods string `json:"return_likelihoods,omitempty"`
+
+	//optional - One of en|pt|sp|fr|de to specify the language of the prompt. By default, the language is English.
+	Language string `json:"language,omitempty"`
 }
 
 type Generation struct {

--- a/generate.go
+++ b/generate.go
@@ -60,7 +60,8 @@ type GenerateOptions struct {
 	// text.
 	ReturnLikelihoods string `json:"return_likelihoods,omitempty"`
 
-	// optional - One of en|pt|sp|fr|de to specify the language of the prompt. By default, the language is English.
+	// optional - Language code (eg: "fr" for French) to specify the language of the generated text.
+	// Support for languages varies between models. By default, the language is set to English.
 	Language string `json:"language,omitempty"`
 }
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -15,6 +15,7 @@ func TestGenerate(t *testing.T) {
 			Prompt:      "Hello my name is",
 			MaxTokens:   10,
 			Temperature: 0.75,
+			Language:    "en",
 		})
 		if err != nil {
 			t.Errorf("expected result, got error: %s", err.Error())


### PR DESCRIPTION
As part of https://github.com/cohere-ai/blobheart/pull/3680 the Generate API now accepts a "language" parameter. This PR updates the SDK to accept "language" as an argument and include it in the API request.