### PR TITLE
Change model param to use body instead of url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import (
 func main() {
   co := cohere.CreateClient("YOUR_API_KEY")
 
-  res, err := co.Generate("large", cohere.GenerateOptions{
+  res, err := co.Generate(cohere.GenerateOptions{
     Prompt:            "co:here",
     MaxTokens:         10,
     Temperature:       0.75,

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ func main() {
   co := cohere.CreateClient("YOUR_API_KEY")
 
   res, err := co.Generate(cohere.GenerateOptions{
+    Model:             "large",
     Prompt:            "co:here",
     MaxTokens:         10,
     Temperature:       0.75,

--- a/classify.go
+++ b/classify.go
@@ -1,6 +1,9 @@
 package cohere
 
 type ClassifyOptions struct {
+	// An optional string representing the model you'd like to use.
+	Model string `json:"model,omitempty"`
+
 	// An optional string representing what you'd like the model to do.
 	TaskDescription string `json:"taskDescription,omitempty"`
 

--- a/classify_test.go
+++ b/classify_test.go
@@ -11,7 +11,7 @@ func TestClassify(t *testing.T) {
 	}
 
 	t.Run("ClassifySuccessMinimumFields", func(t *testing.T) {
-		res, err := co.Classify("medium", ClassifyOptions{
+		res, err := co.Classify(ClassifyOptions{
 			Inputs: []string{"purple"},
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},
@@ -28,7 +28,8 @@ func TestClassify(t *testing.T) {
 	})
 
 	t.Run("ClassifySuccessAllFields", func(t *testing.T) {
-		res, err := co.Classify("medium", ClassifyOptions{
+		res, err := co.Classify(ClassifyOptions{
+			Model:           "medium",
 			TaskDescription: "Classify these words as either a color or a fruit.",
 			Inputs:          []string{"grape", "pink"},
 			Examples: []Example{
@@ -50,7 +51,8 @@ func TestClassify(t *testing.T) {
 	})
 
 	t.Run("ClassifySuccessTaskDescription", func(t *testing.T) {
-		res, err := co.Classify("medium", ClassifyOptions{
+		res, err := co.Classify(ClassifyOptions{
+			Model:           "medium",
 			TaskDescription: "Classify these words as a fruit or a color",
 			Inputs:          []string{"kiwi"},
 			Examples: []Example{
@@ -68,7 +70,8 @@ func TestClassify(t *testing.T) {
 	})
 
 	t.Run("ClassifySuccessOutputIndicator", func(t *testing.T) {
-		res, err := co.Classify("medium", ClassifyOptions{
+		res, err := co.Classify(ClassifyOptions{
+			Model:  "medium",
 			Inputs: []string{"pineapple"},
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},

--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"path"
 
 	"github.com/cohere-ai/tokenizer"
 )
@@ -58,8 +57,8 @@ func CreateClient(apiKey string) (*Client, error) {
 
 // Client methods
 
-func (c *Client) post(model string, endpoint string, body interface{}) ([]byte, error) {
-	url := c.BaseURL + path.Join(model, endpoint)
+func (c *Client) post(endpoint string, body interface{}) ([]byte, error) {
+	url := c.BaseURL + endpoint
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -135,12 +134,12 @@ func (c *Client) CheckAPIKey() ([]byte, error) {
 // Generates realistic text conditioned on a given input.
 // See: https://docs.cohere.ai/generate-reference
 // Returns a GenerateResponse object.
-func (c *Client) Generate(model string, opts GenerateOptions) (*GenerateResponse, error) {
+func (c *Client) Generate(opts GenerateOptions) (*GenerateResponse, error) {
 	if opts.NumGenerations == 0 {
 		opts.NumGenerations = 1
 	}
 
-	res, err := c.post(model, endpointGenerate, opts)
+	res, err := c.post(endpointGenerate, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +154,8 @@ func (c *Client) Generate(model string, opts GenerateOptions) (*GenerateResponse
 // Classifies text as one of the given labels. Returns a confidence score for each label.
 // See: https://docs.cohere.ai/classify-reference
 // Returns a ClassifyResponse object.
-func (c *Client) Classify(model string, opts ClassifyOptions) (*ClassifyResponse, error) {
-	res, err := c.post(model, endpointClassify, opts)
+func (c *Client) Classify(opts ClassifyOptions) (*ClassifyResponse, error) {
+	res, err := c.post(endpointClassify, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -172,8 +171,8 @@ func (c *Client) Classify(model string, opts ClassifyOptions) (*ClassifyResponse
 // information about the text that it represents.
 // See: https://docs.cohere.ai/embed-reference
 // Returns an EmbedResponse object.
-func (c *Client) Embed(model string, opts EmbedOptions) (*EmbedResponse, error) {
-	res, err := c.post(model, endpointEmbed, opts)
+func (c *Client) Embed(opts EmbedOptions) (*EmbedResponse, error) {
+	res, err := c.post(endpointEmbed, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +187,8 @@ func (c *Client) Embed(model string, opts EmbedOptions) (*EmbedResponse, error) 
 // Extracts entities of specified types from the provided text. Each extraction
 // contains a type and a value.
 // Returns an ExtractResponse object.
-func (c *Client) Extract(model string, opts ExtractOptions) (*ExtractResponse, error) {
-	res, err := c.post(model, endpointExtract, opts)
+func (c *Client) Extract(opts ExtractOptions) (*ExtractResponse, error) {
+	res, err := c.post(endpointExtract, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/embed.go
+++ b/embed.go
@@ -8,6 +8,8 @@ const (
 )
 
 type EmbedOptions struct {
+	// An optional string representing the model you'd like to use.
+	Model string `json:"model,omitempty"`
 	// An array of strings for the model to embed.
 	Texts    []string `json:"texts"`
 	Truncate string   `json:"truncate"`

--- a/embed_test.go
+++ b/embed_test.go
@@ -13,7 +13,8 @@ func TestEmbed(t *testing.T) {
 	t.Run("Embed", func(t *testing.T) {
 		texts := []string{"hello", "goodbye"}
 
-		_, err := co.Embed("small", EmbedOptions{
+		_, err := co.Embed(EmbedOptions{
+			Model:    "small",
 			Texts:    texts,
 			Truncate: TruncateNone,
 		})

--- a/example/main.go
+++ b/example/main.go
@@ -21,7 +21,7 @@ func main() {
 	}
 
 	prompt := "What is your"
-	res, err := co.Generate("medium", cohere.GenerateOptions{
+	res, err := co.Generate(cohere.GenerateOptions{
 		Prompt:            prompt,
 		MaxTokens:         20,
 		Temperature:       1,

--- a/example/main.go
+++ b/example/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	prompt := "What is your"
 	res, err := co.Generate(cohere.GenerateOptions{
+		Model:             "large",
 		Prompt:            prompt,
 		MaxTokens:         20,
 		Temperature:       1,

--- a/extract.go
+++ b/extract.go
@@ -1,6 +1,9 @@
 package cohere
 
 type ExtractOptions struct {
+	// An optional string representing the model you'd like to use.
+	Model string `json:"model,omitempty"`
+
 	// An array of strings that you would like to run extraction on.
 	Texts []string `json:"texts"`
 

--- a/extract_test.go
+++ b/extract_test.go
@@ -13,7 +13,8 @@ func TestExtract(t *testing.T) {
 	}
 
 	t.Run("Extraction with single text", func(t *testing.T) {
-		res, err := co.Extract("medium", ExtractOptions{
+		res, err := co.Extract(ExtractOptions{
+			Model: "medium",
 			Texts: []string{"Jim just came back from soccer practice."},
 			Examples: []ExtractExample{
 				{
@@ -45,7 +46,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("Extraction with multiple text inputs", func(t *testing.T) {
-		res, err := co.Extract("medium", ExtractOptions{
+		res, err := co.Extract(ExtractOptions{
+			Model: "medium",
 			Texts: []string{"Jim just came back from soccer practice.", "Who knew that Scott would be so good at chess??"},
 			Examples: []ExtractExample{
 				{
@@ -84,7 +86,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("Run extraction on text with partial entity matching", func(t *testing.T) {
-		res, err := co.Extract("medium", ExtractOptions{
+		res, err := co.Extract(ExtractOptions{
+			Model: "medium",
 			Texts: []string{"Jared just returned."},
 			Examples: []ExtractExample{
 				{
@@ -116,7 +119,8 @@ func TestExtract(t *testing.T) {
 	})
 
 	t.Run("Run extraction on text with no matched entities", func(t *testing.T) {
-		res, err := co.Extract("medium", ExtractOptions{
+		res, err := co.Extract(ExtractOptions{
+			Model: "medium",
 			Texts: []string{"Shirt size XXL."},
 			Examples: []ExtractExample{
 				{

--- a/generate.go
+++ b/generate.go
@@ -17,6 +17,9 @@ type TokenLikelihood struct {
 }
 
 type GenerateOptions struct {
+	// An optional string representing the model you'd like to use.
+	Model string `json:"model,omitempty"`
+
 	// Represents the prompt or text to be completed.
 	Prompt string `json:"prompt"`
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -11,7 +11,8 @@ func TestGenerate(t *testing.T) {
 	}
 
 	t.Run("Generate basic", func(t *testing.T) {
-		_, err := co.Generate("medium", GenerateOptions{
+		_, err := co.Generate(GenerateOptions{
+			Model:       "medium",
 			Prompt:      "Hello my name is",
 			MaxTokens:   10,
 			Temperature: 0.75,
@@ -23,7 +24,8 @@ func TestGenerate(t *testing.T) {
 
 	t.Run("Generate multi", func(t *testing.T) {
 		num := 4
-		res, err := co.Generate("medium", GenerateOptions{
+		res, err := co.Generate(GenerateOptions{
+			Model:          "medium",
 			Prompt:         "What is your",
 			MaxTokens:      10,
 			Temperature:    0.75,
@@ -37,7 +39,8 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("Generate likelihood with generation", func(t *testing.T) {
-		res, err := co.Generate("medium", GenerateOptions{
+		res, err := co.Generate(GenerateOptions{
+			Model:             "medium",
 			Prompt:            "Hello my name is",
 			MaxTokens:         10,
 			Temperature:       0.75,
@@ -52,7 +55,8 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("Generate likelihood with all", func(t *testing.T) {
-		res, err := co.Generate("medium", GenerateOptions{
+		res, err := co.Generate(GenerateOptions{
+			Model:             "medium",
 			Prompt:            "Hello my name is",
 			MaxTokens:         10,
 			Temperature:       0.75,
@@ -67,7 +71,8 @@ func TestGenerate(t *testing.T) {
 	})
 
 	t.Run("Generate likelihood with none", func(t *testing.T) {
-		res, err := co.Generate("medium", GenerateOptions{
+		res, err := co.Generate(GenerateOptions{
+			Model:             "medium",
 			Prompt:            "Hello my name is",
 			MaxTokens:         10,
 			Temperature:       0.75,


### PR DESCRIPTION
As a part of cohere-ai/blobheart#3963 all endpoints will now take model as an optional param in the body instead of the URL. The old URL model will still be supported but will eventually be deprecated. 