### PR TITLE
retract all v1 releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,15 @@ module github.com/cohere-ai/cohere-go
 
 go 1.17
 
+retract ( // retract all v1 and v2 releases, use v0 instead
+	v1.0.0
+	v1.1.0
+	v1.2.0
+	v1.2.1
+	v2.0.0
+	v2.0.0-alpha.1
+)
+
 require (
 	github.com/cohere-ai/tokenizer v1.0.4
 	github.com/stretchr/testify v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,11 @@ module github.com/cohere-ai/cohere-go
 
 go 1.17
 
-retract ( // retract all v1 and v2 releases, use v0 instead
+retract ( // retract all v1 releases, use v0 instead
 	v1.0.0
 	v1.1.0
 	v1.2.0
 	v1.2.1
-	v2.0.0
-	v2.0.0-alpha.1
 )
 
 require (


### PR DESCRIPTION
Will release and tag this as v1.2.1 so that it can retract itself. Will also release a v0.1.0 so that it becomes the newest release