### PR TITLE
Return token_strings in the response for Tokenize

### DIFF
--- a/client.go
+++ b/client.go
@@ -211,7 +211,10 @@ func Tokenize(opts TokenizeOptions) (*TokenizeResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	ret := &TokenizeResponse{encoder.Encode(opts.Text)}
+	tokens, tokenStrings := encoder.Encode(opts.Text)
+	ret := &TokenizeResponse{
+		Tokens:       tokens,
+		TokenStrings: tokenStrings,
+	}
 	return ret, nil
 }

--- a/example/main.go
+++ b/example/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cohere-ai/cohere-go"
+	cohere "github.com/cohere-ai/cohere-go"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/cohere-ai/cohere-go
 go 1.17
 
 retract ( // retract all v1 releases, use v0 instead
-	v1.0.0
-	v1.1.0
-	v1.2.0
 	v1.2.1
+	v1.2.0
+	v1.1.0
+	v1.0.0
 )
 
 require (
-	github.com/cohere-ai/tokenizer v1.0.4
+	github.com/cohere-ai/tokenizer v1.1.1
 	github.com/stretchr/testify v1.7.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cohere-ai/tokenizer v1.0.4 h1:x0ThSj6RiPA78CYHDKdfN9f6VwajW36DlOwXUvYn5Cs=
-github.com/cohere-ai/tokenizer v1.0.4/go.mod h1:9MNFPd9j1fuiEK3ua2HSCUxxcrfGMlSqpa93livg/C0=
+github.com/cohere-ai/tokenizer v1.1.1 h1:wCtmCj07O82TMrIiA/CORhIlEYsvMMM8ey+sUdEapHc=
+github.com/cohere-ai/tokenizer v1.1.1/go.mod h1:9MNFPd9j1fuiEK3ua2HSCUxxcrfGMlSqpa93livg/C0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
@@ -9,10 +9,10 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tokenize_test.go
+++ b/tokenize_test.go
@@ -2,18 +2,24 @@ package cohere
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTokenize(t *testing.T) {
 	t.Run("TokenizeSuccess", func(t *testing.T) {
-		text := "tokenize me!"
+		text := "hello world"
 
-		_, err := Tokenize(TokenizeOptions{
+		res, err := Tokenize(TokenizeOptions{
 			Text: text,
 		})
 		if err != nil {
 			t.Errorf("Expected result, got error: %s", err.Error())
 		}
+		expectedTokens := []int64{33555, 1114}
+		expectedTokenStrings := []string{"hello", " world"}
+		assert.Equal(t, expectedTokens, res.Tokens)
+		assert.Equal(t, expectedTokenStrings, res.TokenStrings)
 	})
 
 	t.Run("TokenizeEmptyText", func(t *testing.T) {

--- a/tokens.go
+++ b/tokens.go
@@ -6,6 +6,8 @@ type TokenizeOptions struct {
 }
 
 type TokenizeResponse struct {
-	// The tokens.
+	// The tokens
 	Tokens []int64 `json:"tokens"`
+	// String representations of the tokens
+	TokenStrings []string `json:"tokenStrings"`
 }

--- a/vendor/github.com/cohere-ai/tokenizer/README.md
+++ b/vendor/github.com/cohere-ai/tokenizer/README.md
@@ -4,7 +4,7 @@ Cohere's `tokenizers` library provides an interface to encode and decode text gi
 We plan on eventually also open sourcing tools to create new tokenizers. 
 
 ## Example using Go
-Choose a tokenizer inside of the trained-tokenizers folder including both a `encoder.json` file and a `vocab.bpe` file and create an encoder as seen below. The tokenizer used in this example is named the `coheretext-50k` tokenizer.
+Choose a tokenizer inside of the vocab folder including both a `encoder.json` file and a `vocab.bpe` file and create an encoder as seen below. The tokenizer used in this example is named the `coheretext-50k` tokenizer.
 ```
 import (
   ...
@@ -14,7 +14,7 @@ import (
 encoder := tokenizer.NewFromPrebuilt("coheretext-50k")
 ```
     
-To encode a string of text, use the Encode method. Encode returns a slice of `int64s`.
+To encode a string of text, use the Encode method. Encode returns a slice of `int64`s.
 ```
 encoded := encoder.Encode("this is a string to be encoded")
 fmt.Printf("%v", encoded)

--- a/vendor/github.com/cohere-ai/tokenizer/bpe.go
+++ b/vendor/github.com/cohere-ai/tokenizer/bpe.go
@@ -91,16 +91,17 @@ func getMaxStat(stats map[[2]string]int64) [2]string {
 }
 
 func pruneStats(stats, bigStats map[[2]string]int64, threshold float64) {
-	pruntCount := 0
+	var pruneCount int64
 	for item, freq := range stats {
-		if float64(freq) < threshold {
-			delete(stats, item)
-			pruntCount++
-			if freq < 0 {
-				bigStats[item] += freq
-			} else {
-				bigStats[item] = freq
-			}
+		if float64(freq) >= threshold {
+			continue
+		}
+		delete(stats, item)
+		pruneCount++
+		if freq < 0 {
+			bigStats[item] += freq
+		} else {
+			bigStats[item] = freq
 		}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/cohere-ai/tokenizer v1.0.4
+# github.com/cohere-ai/tokenizer v1.1.1
 ## explicit; go 1.17
 github.com/cohere-ai/tokenizer
 # github.com/davecgh/go-spew v1.1.0


### PR DESCRIPTION
The API response of tokenize now includes a token_strings field. This PR adds it to the SDK.

Example:
`cohere.Tokenize({"hello world"})`
```
&TokenizeResponse{
	Tokens:       []int64{33555, 1114},
	TokenStrings: []string{"hello", " world"},
}
```