### PR TITLE
change classify response to use labels field instead of confidences

### DIFF
--- a/classify.go
+++ b/classify.go
@@ -25,16 +25,28 @@ type Example struct {
 	Label string `json:"label"`
 }
 
+type Confidence struct {
+	// The label.
+	Label string `json:"label"`
+
+	// The associated confidence with the label.
+	Confidence float32 `json:"confidence"`
+}
+
 type LabelPrediction struct {
 	// The associated confidence with the label.
 	Confidence float32 `json:"confidence"`
 }
+
 type Classification struct {
 	// The text that is being classified.
 	Input string `json:"input"`
 
 	// The predicted label for the text.
 	Prediction string `json:"prediction"`
+
+	// The confidence score for each label.
+	Confidences []Confidence `json:"confidences"`
 
 	// The prediction for each label
 	Labels map[string]LabelPrediction `json:"labels"`

--- a/classify.go
+++ b/classify.go
@@ -25,10 +25,7 @@ type Example struct {
 	Label string `json:"label"`
 }
 
-type Confidence struct {
-	// The label.
-	Label string `json:"label"`
-
+type LabelPrediction struct {
 	// The associated confidence with the label.
 	Confidence float32 `json:"confidence"`
 }
@@ -39,8 +36,8 @@ type Classification struct {
 	// The predicted label for the text.
 	Prediction string `json:"prediction"`
 
-	// The confidence score for each label.
-	Confidences []Confidence `json:"confidences"`
+	// The prediction for each label
+	Labels map[string]LabelPrediction `json:"labels"`
 }
 
 type ClassifyResponse struct {


### PR DESCRIPTION
Classify endpoint now returns a map of labels to their confidences. The old confidences array is being deprecated so it should get removed from the SDK.

Tests will pass once classify changes are deployed.