### PR TITLE
Make optional args in generate optional with pointers and helpers

### DIFF
--- a/client.go
+++ b/client.go
@@ -140,10 +140,6 @@ func (c *Client) CheckAPIKey() ([]byte, error) {
 // See: https://docs.cohere.ai/generate-reference
 // Returns a GenerateResponse object.
 func (c *Client) Generate(opts GenerateOptions) (*GenerateResponse, error) {
-	if opts.NumGenerations == nil || *opts.NumGenerations == 0 {
-		opts.NumGenerations = Int(1)
-	}
-
 	res, err := c.post(endpointGenerate, opts)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -140,8 +140,8 @@ func (c *Client) CheckAPIKey() ([]byte, error) {
 // See: https://docs.cohere.ai/generate-reference
 // Returns a GenerateResponse object.
 func (c *Client) Generate(opts GenerateOptions) (*GenerateResponse, error) {
-	if opts.NumGenerations == 0 {
-		opts.NumGenerations = 1
+	if opts.NumGenerations == nil || *opts.NumGenerations == 0 {
+		opts.NumGenerations = Int(1)
 	}
 
 	res, err := c.post(endpointGenerate, opts)

--- a/example/main.go
+++ b/example/main.go
@@ -24,10 +24,10 @@ func main() {
 	res, err := co.Generate(cohere.GenerateOptions{
 		Model:             "large",
 		Prompt:            prompt,
-		MaxTokens:         20,
-		Temperature:       1,
-		K:                 5,
-		P:                 0,
+		MaxTokens:         cohere.Uint(20),
+		Temperature:       cohere.Float64(1),
+		K:                 cohere.Int(5),
+		P:                 cohere.Float64(0),
 		StopSequences:     []string{"?"},
 		ReturnLikelihoods: cohere.ReturnAll,
 	})

--- a/generate.go
+++ b/generate.go
@@ -23,37 +23,37 @@ type GenerateOptions struct {
 	// Represents the prompt or text to be completed.
 	Prompt string `json:"prompt,omitempty"`
 
-	// Denotes the number of tokens to predict per generation.
-	MaxTokens uint `json:"max_tokens,omitempty"`
+	// optional - Denotes the number of tokens to predict per generation.
+	MaxTokens *uint `json:"max_tokens,omitempty"`
 
 	// optional - The ID of a custom playground preset.
 	Preset string `json:"preset,omitempty"`
 
-	// A non-negative float that tunes the degree of randomness in generation.
-	Temperature float64 `json:"temperature"`
+	// optional - A non-negative float that tunes the degree of randomness in generation.
+	Temperature *float64 `json:"temperature,omitempty"`
 
 	// optional - Denotes the maximum number of generations that will be returned. Defaults to 1,
 	// max value of 5.
-	NumGenerations int `json:"num_generations"`
+	NumGenerations *int `json:"num_generations,omitempty"`
 
 	// optional - If set to a positive integer, it ensures only the top k most likely tokens are
 	// considered for generation at each step.
-	K int `json:"k"`
+	K *int `json:"k,omitempty"`
 
 	// optional - If set to a probability 0.0 < p < 1.0, it ensures that only the most likely tokens,
 	// with total probability mass of p, are considered for generation at each step. If both k and
 	// p are enabled, p acts after k. Max value of 1.0.
-	P float64 `json:"p"`
+	P *float64 `json:"p,omitempty"`
 
 	// optional - Can be used to reduce repetitiveness of generated tokens. The higher the value,
 	// the stronger a penalty is applied to previously present tokens, proportional to how many
 	// times they have already appeared in the prompt or prior generation. Max value of 1.0.
-	FrequencyPenalty float64 `json:"frequency_penalty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
 
 	// optional - Can be used to reduce repetitiveness of generated tokens. Similar to frequency_penalty,
 	// except that this penalty is applied equally to all tokens that have already appeared, regardless
 	// of their exact frequencies. Max value of 1.0.
-	PresencePenalty float64 `json:"presence_penalty"`
+	PresencePenalty *float64 `json:"presence_penalty,omitempty"`
 
 	// optional - A stop sequence will cut off your generation at the end of the sequence. Providing multiple
 	// stop sequences in the array will cut the generation at the first stop sequence in the generation,

--- a/generate_test.go
+++ b/generate_test.go
@@ -14,8 +14,8 @@ func TestGenerate(t *testing.T) {
 		_, err := co.Generate(GenerateOptions{
 			Model:       "medium",
 			Prompt:      "Hello my name is",
-			MaxTokens:   10,
-			Temperature: 0.75,
+			MaxTokens:   Uint(10),
+			Temperature: Float64(0.75),
 		})
 		if err != nil {
 			t.Errorf("expected result, got error: %s", err.Error())
@@ -27,9 +27,9 @@ func TestGenerate(t *testing.T) {
 		res, err := co.Generate(GenerateOptions{
 			Model:          "medium",
 			Prompt:         "What is your",
-			MaxTokens:      10,
-			Temperature:    0.75,
-			NumGenerations: num,
+			MaxTokens:      Uint(10),
+			Temperature:    Float64(0.75),
+			NumGenerations: Int(num),
 		})
 		if err != nil {
 			t.Errorf("expected result, got error: %s", err.Error())
@@ -42,8 +42,8 @@ func TestGenerate(t *testing.T) {
 		res, err := co.Generate(GenerateOptions{
 			Model:             "medium",
 			Prompt:            "Hello my name is",
-			MaxTokens:         10,
-			Temperature:       0.75,
+			MaxTokens:         Uint(10),
+			Temperature:       Float64(0.75),
 			ReturnLikelihoods: "GENERATION",
 		})
 		if err != nil {
@@ -58,8 +58,8 @@ func TestGenerate(t *testing.T) {
 		res, err := co.Generate(GenerateOptions{
 			Model:             "medium",
 			Prompt:            "Hello my name is",
-			MaxTokens:         10,
-			Temperature:       0.75,
+			MaxTokens:         Uint(10),
+			Temperature:       Float64(0.75),
 			ReturnLikelihoods: "ALL",
 		})
 		if err != nil {
@@ -74,8 +74,8 @@ func TestGenerate(t *testing.T) {
 		res, err := co.Generate(GenerateOptions{
 			Model:             "medium",
 			Prompt:            "Hello my name is",
-			MaxTokens:         10,
-			Temperature:       0.75,
+			MaxTokens:         Uint(10),
+			Temperature:       Float64(0.75),
 			ReturnLikelihoods: "NONE",
 		})
 		if err != nil {
@@ -99,8 +99,8 @@ func TestGenerate(t *testing.T) {
 		_, err := co.Generate(GenerateOptions{
 			Model:       "medium",
 			Prompt:      "Hello my name is",
-			MaxTokens:   10,
-			Temperature: 0.75,
+			MaxTokens:   Uint(10),
+			Temperature: Float64(0.75),
 			LogitBias:   map[int]float32{11: -5, 33: 7.5},
 		})
 		if err != nil {

--- a/pointer.go
+++ b/pointer.go
@@ -1,0 +1,13 @@
+package cohere
+
+func Int(i int) *int {
+	return &i
+}
+
+func Uint(i uint) *uint {
+	return &i
+}
+
+func Float64(f float64) *float64 {
+	return &f
+}


### PR DESCRIPTION
It's impossible to set a value to its default value ie 0, "", empty list without it getting removed from the request. This changes some fields to use pointers instead so we can explicitly set these params as the default value.