### PR TITLE
remove taskdescription & outputIndicator

### DIFF
--- a/classify.go
+++ b/classify.go
@@ -7,17 +7,11 @@ type ClassifyOptions struct {
 	// An optional string representing the ID of a custom playground preset.
 	Preset string `json:"preset,omitempty"`
 
-	// An optional string representing what you'd like the model to do.
-	TaskDescription string `json:"taskDescription,omitempty"`
-
 	// An array of strings that you would like to classify.
 	Inputs []string `json:"inputs"`
 
 	// An array of ClassifyExamples representing examples and the corresponding label.
 	Examples []Example `json:"examples"`
-
-	// An optional string to append onto every example and text prior to the label.
-	OutputIndicator string `json:"outputIndicator,omitempty"`
 }
 
 type Example struct {

--- a/classify_test.go
+++ b/classify_test.go
@@ -29,13 +29,11 @@ func TestClassify(t *testing.T) {
 
 	t.Run("ClassifySuccessAllFields", func(t *testing.T) {
 		res, err := co.Classify(ClassifyOptions{
-			Model:           "medium",
-			TaskDescription: "Classify these words as either a color or a fruit.",
-			Inputs:          []string{"grape", "pink"},
+			Model:  "medium",
+			Inputs: []string{"grape", "pink"},
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},
 				{"red", "color"}, {"blue", "color"}, {"blue", "color"}, {"yellow", "color"}, {"green", "color"}},
-			OutputIndicator: "This is a",
 		})
 
 		if err != nil {
@@ -52,9 +50,8 @@ func TestClassify(t *testing.T) {
 
 	t.Run("ClassifySuccessTaskDescription", func(t *testing.T) {
 		res, err := co.Classify(ClassifyOptions{
-			Model:           "medium",
-			TaskDescription: "Classify these words as a fruit or a color",
-			Inputs:          []string{"kiwi"},
+			Model:  "medium",
+			Inputs: []string{"kiwi"},
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},
 				{"red", "color"}, {"blue", "color"}, {"blue", "color"}, {"yellow", "color"}, {"green", "color"}},
@@ -76,7 +73,6 @@ func TestClassify(t *testing.T) {
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},
 				{"red", "color"}, {"blue", "color"}, {"blue", "color"}, {"yellow", "color"}, {"green", "color"}},
-			OutputIndicator: "This is a",
 		})
 
 		if err != nil {


### PR DESCRIPTION
Now that we moved away from GPT Classify, these parameters are not necessary anymore.

Tested by making calls.