### PR TITLE
[Major][Breaking] Remove "confidences" field from Classify response

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
-          args: --timeout=3m0s

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ func main() {
     return
   }
 
-  co.Version = "2021-11-08"
+  co.Version = "2022-12-06"
 }
 ```
 

--- a/classify.go
+++ b/classify.go
@@ -29,15 +29,24 @@ type Confidence struct {
 	// The associated confidence with the label.
 	Confidence float32 `json:"confidence"`
 }
-type Classification struct {
-	// The text that is being classified.
-	Input string `json:"input"`
 
-	// The predicted label for the text.
+type LabelConfidence struct {
+	Confidence float32 `json:"confidence"`
+}
+
+type Classification struct {
+
+	// The top predicted label for the text.
 	Prediction string `json:"prediction"`
 
-	// The confidence score for each label.
-	Confidences []Confidence `json:"confidences"`
+	// Confidence score for the top predicted label.
+	Confidence float32 `json:"confidence"`
+
+	// Confidence score for each label.
+	Labels map[string]LabelConfidence `json:"labels"`
+
+	// The text that is being classified.
+	Input string `json:"input"`
 }
 
 type ClassifyResponse struct {

--- a/classify.go
+++ b/classify.go
@@ -30,7 +30,7 @@ type Confidence struct {
 	Confidence float32 `json:"confidence"`
 }
 
-type LabelConfidence struct {
+type LabelProperties struct {
 	Confidence float32 `json:"confidence"`
 }
 
@@ -43,7 +43,7 @@ type Classification struct {
 	Confidence float32 `json:"confidence"`
 
 	// Confidence score for each label.
-	Labels map[string]LabelConfidence `json:"labels"`
+	Labels map[string]LabelProperties `json:"labels"`
 
 	// The text that is being classified.
 	Input string `json:"input"`

--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func CreateClient(apiKey string) (*Client, error) {
 		APIKey:  apiKey,
 		BaseURL: "https://api.cohere.ai/",
 		Client:  *http.DefaultClient,
-		Version: "2021-11-08",
+		Version: "2022-12-06",
 	}
 
 	res, err := client.CheckAPIKey()


### PR DESCRIPTION
- Update API version to the latest 2022-12-06
- Remove "confidences" field from the Classify response
- Fix Linting workflow errors