### PR TITLE
Add API for detecting language

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
-          args: --timeout=3m0s

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch file",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${file}"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ func main() {
 
 For a full breakdown of endpoints and arguments, please consult the [Cohere Docs](https://docs.cohere.ai/).
 
-| Cohere Endpoint | Function        |
-| --------------- | --------------- |
-| /generate       | co.Generate()   |
-| /embed          | co.Embed()      |
-| /classify       | co.Classify()   |
-| /tokenize       | co.Tokenize()   |
-| /detokenize     | co.Detokenize() |
+| Cohere Endpoint  | Function            |
+| ---------------- | ------------------- |
+| /generate        | co.Generate()       |
+| /embed           | co.Embed()          |
+| /classify        | co.Classify()       |
+| /tokenize        | co.Tokenize()       |
+| /detokenize      | co.Detokenize()     |
+| /detect-language | co.DetectLanguage() |
 
 ## Models
 

--- a/client.go
+++ b/client.go
@@ -20,9 +20,10 @@ type Client struct {
 }
 
 const (
-	endpointGenerate = "generate"
-	endpointEmbed    = "embed"
-	endpointClassify = "classify"
+	endpointGenerate       = "generate"
+	endpointEmbed          = "embed"
+	endpointClassify       = "classify"
+	endpointDetectLanguage = "detect-language"
 
 	endpointCheckAPIKey = "check-api-key"
 )
@@ -218,6 +219,22 @@ func Detokenize(opts DetokenizeOptions) (*DetokenizeResponse, error) {
 	text := encoder.Decode(opts.Tokens)
 	ret := &DetokenizeResponse{
 		Text: text,
+	}
+	return ret, nil
+}
+
+// For each of the provided texts, returns the expected language of that text.
+// See: https://docs.cohere.ai/detect-language-reference
+// Returns a DetectLanguageResponse object.
+func (c *Client) DetectLanguage(opts DetectLanguageOptions) (*DetectLanguageResponse, error) {
+	res, err := c.post(endpointDetectLanguage, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := &DetectLanguageResponse{}
+	if err := json.Unmarshal(res, ret); err != nil {
+		return nil, err
 	}
 	return ret, nil
 }

--- a/detectlanguage.go
+++ b/detectlanguage.go
@@ -5,7 +5,7 @@ type Language struct {
 	LanguageName string `json:"language_name"`
 
 	// Code of the language, eg "fr"
-	LanguageCode *float64 `json:"language_code"`
+	LanguageCode string `json:"language_code"`
 
 	// A score between 0 and 1 that represents the confidence of the result.
 	Confidence float32 `json:"confidence"`

--- a/detectlanguage.go
+++ b/detectlanguage.go
@@ -1,14 +1,11 @@
 package cohere
 
-type Language struct {
+type LanguageDetectResult struct {
 	// Name of the language, eg "French"
 	LanguageName string `json:"language_name"`
 
 	// Code of the language, eg "fr"
 	LanguageCode string `json:"language_code"`
-
-	// A score between 0 and 1 that represents the confidence of the result.
-	Confidence float32 `json:"confidence"`
 }
 
 type DetectLanguageOptions struct {
@@ -18,5 +15,5 @@ type DetectLanguageOptions struct {
 
 type DetectLanguageResponse struct {
 	// List of detected languages, one per text
-	Results []Language `json:"results"`
+	Results []LanguageDetectResult `json:"results"`
 }

--- a/detectlanguage.go
+++ b/detectlanguage.go
@@ -1,0 +1,22 @@
+package cohere
+
+type Language struct {
+	// Name of the language, eg "French"
+	LanguageName string `json:"language_name"`
+
+	// Code of the language, eg "fr"
+	LanguageCode *float64 `json:"language_code"`
+
+	// A score between 0 and 1 that represents the confidence of the result.
+	Confidence float32 `json:"confidence"`
+}
+
+type DetectLanguageOptions struct {
+	// Texts to identify languages for
+	Texts []string `json:"texts"`
+}
+
+type DetectLanguageResponse struct {
+	// List of detected languages, one per text
+	Results []Language `json:"results"`
+}

--- a/detectlanguage_test.go
+++ b/detectlanguage_test.go
@@ -19,9 +19,7 @@ func TestDetectLanguage(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, res.Results[0].LanguageCode, "en")
 		assert.Equal(t, res.Results[0].LanguageName, "English")
-		assert.Positive(t, res.Results[0].Confidence)
 		assert.Equal(t, res.Results[1].LanguageCode, "ru")
 		assert.Equal(t, res.Results[1].LanguageName, "Russian")
-		assert.Positive(t, res.Results[1].Confidence)
 	})
 }

--- a/detectlanguage_test.go
+++ b/detectlanguage_test.go
@@ -18,6 +18,10 @@ func TestDetectLanguage(t *testing.T) {
 		})
 		assert.Nil(t, err)
 		assert.Equal(t, res.Results[0].LanguageCode, "en")
+		assert.Equal(t, res.Results[0].LanguageName, "English")
+		assert.Positive(t, res.Results[0].Confidence)
 		assert.Equal(t, res.Results[1].LanguageCode, "ru")
+		assert.Equal(t, res.Results[1].LanguageName, "Russian")
+		assert.Positive(t, res.Results[1].Confidence)
 	})
 }

--- a/detectlanguage_test.go
+++ b/detectlanguage_test.go
@@ -1,0 +1,23 @@
+package cohere
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectLanguage(t *testing.T) {
+	co, err := CreateClient(apiKey)
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Run("DetectLanguage success", func(t *testing.T) {
+		res, err := co.DetectLanguage(DetectLanguageOptions{
+			Texts: []string{"this text is in english", "Этот текст на Русском языке."},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, res.Results[0].LanguageCode, "en")
+		assert.Equal(t, res.Results[1].LanguageCode, "ru")
+	})
+}


### PR DESCRIPTION
```golang
res, err := co.DetectLanguage(DetectLanguageOptions{
	Texts: []string{"this text is in english", "Этот текст на Русском языке."},
})

fmt.Print(res.Results[0].LanguageCode) // "en"
fmt.Print(res.Results[0].LanguageName) // "English"

fmt.Print(res.Results[1].LanguageCode) // "ru"
fmt.Print(res.Results[1].LanguageName) // "Russian"
```