### PR TITLE
Add support for end_sequences param for Generate

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
-          args: --timeout=3m0s

--- a/generate.go
+++ b/generate.go
@@ -55,9 +55,12 @@ type GenerateOptions struct {
 	// of their exact frequencies. Max value of 1.0.
 	PresencePenalty *float64 `json:"presence_penalty,omitempty"`
 
-	// optional - A stop sequence will cut off your generation at the end of the sequence. Providing multiple
-	// stop sequences in the array will cut the generation at the first stop sequence in the generation,
-	// if applicable.
+	// optional - The generated text will be cut at the beginning of the earliest occurence of an end sequence.
+	// The sequence will be excluded from the text.
+	EndSequences []string `json:"end_sequences,omitempty"`
+
+	// optional - The generated text will be cut at the end of the earliest occurence of a stop sequence.
+	// The sequence will be included the text.
 	StopSequences []string `json:"stop_sequences,omitempty"`
 
 	// optional - One of GENERATION|ALL|NONE to specify how and if the token likelihoods are returned with


### PR DESCRIPTION
Adds support for the end_sequences param for the Generate API. It acts just like stop_sequences, but the sequence gets excluded from the response.