### PR TITLE
Add missing fields from Classify response

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.29
-          args: --timeout=3m0s

--- a/classify.go
+++ b/classify.go
@@ -36,6 +36,12 @@ type Classification struct {
 	// The predicted label for the text.
 	Prediction string `json:"prediction"`
 
+	// Confidence score for the predicted label.
+	Confidence float32 `json:"confidence"`
+
+	// Confidence scores for each label.
+	Labels map[string]float32 `json:"labels"`
+
 	// The confidence score for each label.
 	Confidences []Confidence `json:"confidences"`
 }

--- a/classify.go
+++ b/classify.go
@@ -29,6 +29,11 @@ type Confidence struct {
 	// The associated confidence with the label.
 	Confidence float32 `json:"confidence"`
 }
+
+type LabelConfidence struct {
+	Confidence float32 `json:"confidence"`
+}
+
 type Classification struct {
 	// The text that is being classified.
 	Input string `json:"input"`
@@ -40,7 +45,7 @@ type Classification struct {
 	Confidence float32 `json:"confidence"`
 
 	// Confidence scores for each label.
-	Labels map[string]float32 `json:"labels"`
+	Labels map[string]LabelConfidence `json:"labels"`
 
 	// The confidence score for each label.
 	Confidences []Confidence `json:"confidences"`

--- a/classify_test.go
+++ b/classify_test.go
@@ -28,9 +28,10 @@ func TestClassify(t *testing.T) {
 	})
 
 	t.Run("ClassifySuccessAllFields", func(t *testing.T) {
+		labels := []string{"grape", "pink"}
 		res, err := co.Classify(ClassifyOptions{
 			Model:  "medium",
-			Inputs: []string{"grape", "pink"},
+			Inputs: labels,
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},
 				{"red", "color"}, {"blue", "color"}, {"blue", "color"}, {"yellow", "color"}, {"green", "color"}},
@@ -45,6 +46,12 @@ func TestClassify(t *testing.T) {
 		}
 		if res.Classifications[1].Prediction != "color" {
 			t.Errorf("Expected: color. Receieved: %s", res.Classifications[1].Prediction)
+		}
+		for _, label := range labels {
+			_, ok := res.Classifications[0].Labels[label]
+			if !ok {
+				t.Errorf("Missing confidence score for label %s", label)
+			}
 		}
 	})
 

--- a/classify_test.go
+++ b/classify_test.go
@@ -1,6 +1,7 @@
 package cohere
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -28,10 +29,9 @@ func TestClassify(t *testing.T) {
 	})
 
 	t.Run("ClassifySuccessAllFields", func(t *testing.T) {
-		labels := []string{"grape", "pink"}
 		res, err := co.Classify(ClassifyOptions{
 			Model:  "medium",
-			Inputs: labels,
+			Inputs: []string{"grape", "pink"},
 			Examples: []Example{
 				{"apple", "fruit"}, {"banana", "fruit"}, {"watermelon", "fruit"}, {"cherry", "fruit"}, {"lemon", "fruit"},
 				{"red", "color"}, {"blue", "color"}, {"blue", "color"}, {"yellow", "color"}, {"green", "color"}},
@@ -47,10 +47,11 @@ func TestClassify(t *testing.T) {
 		if res.Classifications[1].Prediction != "color" {
 			t.Errorf("Expected: color. Receieved: %s", res.Classifications[1].Prediction)
 		}
-		for _, label := range labels {
+		for _, label := range []string{"fruit", "color"} {
 			_, ok := res.Classifications[0].Labels[label]
 			if !ok {
-				t.Errorf("Missing confidence score for label %s", label)
+				fmt.Print(res.Classifications[0].Labels)
+				t.Errorf("Missing confidence score for label'%s'", label)
 			}
 		}
 	})


### PR DESCRIPTION
The Classify response was updated to contain a top level `confidence` score for the predicted label, as well as to include a map of `labels` and their corresponding confidence scores. 