### PR TITLE
feat: add metadata fields to responses of all user-facing endpoints

### DIFF
--- a/classify.go
+++ b/classify.go
@@ -53,4 +53,7 @@ type Classification struct {
 type ClassifyResponse struct {
 	ID              string           `json:"id"`
 	Classifications []Classification `json:"classifications"`
+
+	// Metadata about the API version
+	Meta *MetaResponse `json:"meta,omitempty"`
 }

--- a/detectlanguage.go
+++ b/detectlanguage.go
@@ -16,4 +16,7 @@ type DetectLanguageOptions struct {
 type DetectLanguageResponse struct {
 	// List of detected languages, one per text
 	Results []LanguageDetectResult `json:"results"`
+
+	// Metadata about the API version
+	Meta *MetaResponse `json:"meta,omitempty"`
 }

--- a/detokenize.go
+++ b/detokenize.go
@@ -8,4 +8,7 @@ type DetokenizeOptions struct {
 type DetokenizeResponse struct {
 	// The text represention of the tokens
 	Text string `json:"text"`
+
+	// Metadata about the API version
+	Meta *MetaResponse `json:"meta,omitempty"`
 }

--- a/embed.go
+++ b/embed.go
@@ -19,4 +19,7 @@ type EmbedResponse struct {
 	// An array of embeddings, where each embedding is an array of floats. The length of the embeddings
 	// array will be the same as the length of the original texts array.
 	Embeddings [][]float64
+
+	// Metadata about the API version
+	Meta *MetaResponse `json:"meta,omitempty"`
 }

--- a/generate.go
+++ b/generate.go
@@ -79,7 +79,7 @@ type GenerateOptions struct {
 
 type Generation struct {
 	// ID of the current generation
-	ID string `json:"id`
+	ID string `json:"id"`
 
 	// Contains the generated text.
 	Text string `json:"text"`

--- a/generate.go
+++ b/generate.go
@@ -78,6 +78,9 @@ type GenerateOptions struct {
 }
 
 type Generation struct {
+	// ID of the current generation
+	ID string `json:"id`
+
 	// Contains the generated text.
 	Text string `json:"text"`
 
@@ -92,4 +95,7 @@ type Generation struct {
 type GenerateResponse struct {
 	// Contains the generations.
 	Generations []Generation `json:"generations"`
+
+	// Metadata about the API version
+	Meta *MetaResponse `json:"meta,omitempty"`
 }

--- a/meta.go
+++ b/meta.go
@@ -1,0 +1,12 @@
+package cohere
+
+type MetaResponse struct {
+	APIVersion *APIVersionMeta `json:"api_version"`
+}
+
+// Metadata about the API version being used
+type APIVersionMeta struct {
+	Version        string `json:"version"`
+	IsDeprecated   bool   `json:"is_deprecated,omitempty"`
+	IsExperimental bool   `json:"is_experimental,omitempty"`
+}

--- a/summarize.go
+++ b/summarize.go
@@ -26,4 +26,7 @@ type SummarizeOptions struct {
 type SummarizeResponse struct {
 	Summary string `json:"summary"`
 	ID      string `json:"id"`
+
+	// Metadata about the API version
+	Meta *MetaResponse `json:"meta,omitempty"`
 }


### PR DESCRIPTION
Added the metadata field in the reponses of all endpoints. As discussed with @willie3838, there are situations in which said object can be omitted, hence I've left a pointer here such that it can be `nil` in that case.

Tested by running the unit tests with and without enforcing that the meta field be present.

Closes OS-258