### PR TITLE
fix: change the module path to include the major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ client := cohereclient.NewClient(cohereclient.WithToken("<YOUR_AUTH_TOKEN>"))
 
 ```go
 import (
-  cohere       "github.com/cohere-ai/cohere-go"
-  cohereclient "github.com/cohere-ai/cohere-go/client"
+  cohere       "github.com/cohere-ai/cohere-go/v2"
+  cohereclient "github.com/cohere-ai/cohere-go/v2/client"
 )
 
 client := cohereclient.NewClient(cohereclient.WithToken("<YOUR_AUTH_TOKEN>"))

--- a/client/client.go
+++ b/client/client.go
@@ -8,11 +8,12 @@ import (
 	json "encoding/json"
 	errors "errors"
 	fmt "fmt"
-	coherego "github.com/cohere-ai/cohere-go"
-	core "github.com/cohere-ai/cohere-go/core"
-	dataset "github.com/cohere-ai/cohere-go/dataset"
 	io "io"
 	http "net/http"
+
+	coherego "github.com/cohere-ai/cohere-go/v2"
+	core "github.com/cohere-ai/cohere-go/v2/core"
+	dataset "github.com/cohere-ai/cohere-go/v2/dataset"
 )
 
 type Client struct {

--- a/client/options.go
+++ b/client/options.go
@@ -3,8 +3,9 @@
 package client
 
 import (
-	core "github.com/cohere-ai/cohere-go/core"
 	http "net/http"
+
+	core "github.com/cohere-ai/cohere-go/v2/core"
 )
 
 // WithBaseURL sets the client's base URL, overriding the

--- a/dataset.go
+++ b/dataset.go
@@ -5,8 +5,9 @@ package api
 import (
 	json "encoding/json"
 	fmt "fmt"
-	core "github.com/cohere-ai/cohere-go/core"
 	time "time"
+
+	core "github.com/cohere-ai/cohere-go/v2/core"
 )
 
 type DatasetGetRequest struct {

--- a/dataset/client.go
+++ b/dataset/client.go
@@ -5,11 +5,12 @@ package dataset
 import (
 	context "context"
 	fmt "fmt"
-	coherego "github.com/cohere-ai/cohere-go"
-	core "github.com/cohere-ai/cohere-go/core"
 	http "net/http"
 	url "net/url"
 	time "time"
+
+	coherego "github.com/cohere-ai/cohere-go/v2"
+	core "github.com/cohere-ai/cohere-go/v2/core"
 )
 
 type Client struct {

--- a/errors.go
+++ b/errors.go
@@ -4,7 +4,8 @@ package api
 
 import (
 	json "encoding/json"
-	core "github.com/cohere-ai/cohere-go/core"
+
+	core "github.com/cohere-ai/cohere-go/v2/core"
 )
 
 type BadRequestError struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cohere-ai/cohere-go
+module github.com/cohere-ai/cohere-go/v2
 
 go 1.18
 

--- a/types.go
+++ b/types.go
@@ -5,8 +5,9 @@ package api
 import (
 	json "encoding/json"
 	fmt "fmt"
-	core "github.com/cohere-ai/cohere-go/core"
 	time "time"
+
+	core "github.com/cohere-ai/cohere-go/v2/core"
 )
 
 type ChatRequest struct {


### PR DESCRIPTION
It is currently impossible to use the v2.0.0 release because the module path doesn't end in the major version (it's a requirement for anything >= 2.0.0) - there are more details in the [official docs](https://go.dev/ref/mod#module-path).


The current behaviour is:
```
❯ go get -u github.com/cohere-ai/cohere-go@v2.0.0
go: github.com/cohere-ai/cohere-go@v2.0.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/cohere-ai/cohere-go/v2")
```

This PR changes the module paths to add a `/v2` suffix. It will require a 2.0.1 tag since 2.0.0 has been cached by the go proxy already.

I haven't seen any of the fern configuration, but it will also need to be updated to reflect the new module path.