### PR TITLE
Update README.md to reference /v2 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](banner.png)
 
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-SDK%20generated%20by%20Fern-brightgreen)](https://github.com/fern-api/fern)
-[![go shield](https://img.shields.io/badge/go-docs-blue)](https://pkg.go.dev/github.com/cohere-ai/cohere-go)
+[![go shield](https://img.shields.io/badge/go-docs-blue)](https://pkg.go.dev/github.com/cohere-ai/cohere-go/v2)
 
 The Cohere Go library provides convenient access to the Cohere API from Go.
 
@@ -18,14 +18,15 @@ This module requires Go version >= 1.18.
 ## Installation
 
 Run the following command to use the Cohere Go library in your module:
+
 ```sh
-go get github.com/cohere-ai/cohere-go
+go get github.com/cohere-ai/cohere-go/v2
 ```
 
 ## Usage
 
 ```go
-import cohereclient "github.com/cohere-ai/cohere-go/client"
+import cohereclient "github.com/cohere-ai/cohere-go/v2/client"
 
 client := cohereclient.NewClient(cohereclient.WithToken("<YOUR_AUTH_TOKEN>"))
 ```
@@ -34,8 +35,8 @@ client := cohereclient.NewClient(cohereclient.WithToken("<YOUR_AUTH_TOKEN>"))
 
 ```go
 import (
-  cohere       "github.com/cohere-ai/cohere-go"
-  cohereclient "github.com/cohere-ai/cohere-go/client"
+  cohere       "github.com/cohere-ai/cohere-go/v2"
+  cohereclient "github.com/cohere-ai/cohere-go/v2/client"
 )
 
 client := cohereclient.NewClient(cohereclient.WithToken("<YOUR_AUTH_TOKEN>"))


### PR DESCRIPTION
Now that the module has been renamed to `github.com/cohere-ai/cohere-go/v2` (with the `v2.0.0` release), this updates the `README.md` to reflect the new import paths.