### PR TITLE
Add bedrock and sagemaker clients

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,3 +4,4 @@ LICENSE
 .github/workflows/e2e.yml
 tests/
 .github/workflows/ci.yml
+client/aws.go

--- a/client/aws.go
+++ b/client/aws.go
@@ -1,0 +1,258 @@
+package client
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	errors "errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	option "github.com/cohere-ai/cohere-go/v2/option"
+)
+
+func newAwsRequestOptions(opts ...AwsRequestOption) *AwsRequestOptions {
+	options := &AwsRequestOptions{}
+	for _, opt := range opts {
+		opt.applyRequestOptions(options)
+	}
+	return options
+}
+
+type awsClient struct {
+	AwsRequestOptions
+	Service string
+}
+
+// RequestOption adapts the behavior of the client or an individual request.
+type AwsRequestOption interface {
+	applyRequestOptions(*AwsRequestOptions)
+}
+
+type AwsRequestOptions struct {
+	environment     string
+	awsRegion       string
+	awsAccessKey    string
+	awsSecretKey    string
+	awsSessionToken string
+}
+
+// AwsEnvironment implements the RequestOption interface.
+type AwsEnvironment struct {
+	environment string
+}
+
+func (h *AwsEnvironment) applyRequestOptions(opts *AwsRequestOptions) {
+	opts.environment = h.environment
+}
+
+type AwsRegion struct {
+	awsRegion string
+}
+
+func (h *AwsRegion) applyRequestOptions(opts *AwsRequestOptions) {
+	opts.awsRegion = h.awsRegion
+}
+
+func WithAwsRegion(region string) *AwsRegion {
+	return &AwsRegion{awsRegion: region}
+}
+
+type AwsAccessKey struct {
+	awsAccessKey string
+}
+
+func (h *AwsAccessKey) applyRequestOptions(opts *AwsRequestOptions) {
+	opts.awsAccessKey = h.awsAccessKey
+}
+
+func WithAwsAccessKey(accessKey string) *AwsAccessKey {
+	return &AwsAccessKey{awsAccessKey: accessKey}
+}
+
+type AwsSecretKey struct {
+	awsSecretKey string
+}
+
+func (h *AwsSecretKey) applyRequestOptions(opts *AwsRequestOptions) {
+	opts.awsSecretKey = h.awsSecretKey
+}
+
+func WithAwsSecretKey(secretKey string) *AwsSecretKey {
+	return &AwsSecretKey{awsSecretKey: secretKey}
+}
+
+type AwsSessionToken struct {
+	awsSessionToken string
+}
+
+func (h *AwsSessionToken) applyRequestOptions(opts *AwsRequestOptions) {
+	opts.awsSessionToken = h.awsSessionToken
+}
+
+func WithAwsSessionToken(sessionToken string) *AwsSessionToken {
+	return &AwsSessionToken{awsSessionToken: sessionToken}
+}
+
+func NewAwsClient(baseOpts []option.RequestOption, awsOpts []AwsRequestOption, service string) *Client {
+	options := newAwsRequestOptions(awsOpts...)
+
+	baseOpts = append(
+		baseOpts,
+		WithHTTPClient(&awsClient{Service: service, AwsRequestOptions: *options}),
+		WithToken("n/a"),
+	)
+
+	return NewClient(baseOpts...)
+}
+
+func (b *awsClient) Do(req *http.Request) (*http.Response, error) {
+	isStream, err := b.setModelParams(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = signRequest(b.awsAccessKey, b.awsSecretKey, b.awsSessionToken, b.Service, b.awsRegion, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// map response to expected bedrock stream response
+	if isStream && b.Service == "bedrock" {
+		resBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		// This is a naive implementation that assumes the responses are all in the same format
+		var mappedResponseEvents []string
+		events := strings.Split(string(resBody), "message")
+		for _, event := range events {
+
+			fmt.Println(event)
+			// look for the payload
+			idx := strings.Index(event, "\"bytes\":")
+			if idx == -1 {
+				continue
+			}
+			// get the payload and append it to the mapped response
+			eventBody := strings.Split(event[idx:], "\"")[3]
+
+			idx1 := strings.Index(eventBody, "stream-end")
+			if idx1 != -1 {
+				continue
+			}
+
+			// decode the payload
+			decoded, err := base64.StdEncoding.DecodeString(eventBody)
+			if err != nil {
+				return nil, err
+			}
+			mappedResponseEvents = append(mappedResponseEvents, string(decoded))
+		}
+
+		resp.Body = io.NopCloser(strings.NewReader(strings.Join(mappedResponseEvents, "\n") + "\n"))
+	}
+
+	// parse response
+	return resp, err
+}
+
+// modify the request to point to the bedrock model and remove the model from the request body
+// handle stream param
+func (b *awsClient) setModelParams(req *http.Request) (bool, error) {
+	// try to parse the model from the request body
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		return false, err
+	}
+	jsonBody := map[string]interface{}{}
+	err = json.Unmarshal(reqBody, &jsonBody)
+	if err != nil {
+		return false, err
+	}
+	model, ok := jsonBody["model"].(string)
+	if !ok {
+		return false, errors.New("model not found in request body")
+	}
+	delete(jsonBody, "model")
+	stream, ok := jsonBody["stream"].(bool)
+	if !ok {
+		stream = false
+	} else if b.Service == "bedrock" {
+		delete(jsonBody, "stream")
+	}
+
+	reqBody, err = json.Marshal(jsonBody)
+	if err != nil {
+		return false, err
+	}
+
+	req.URL, err = req.URL.Parse(getUrl(b.Service, b.awsRegion, model, stream))
+	if err != nil {
+		return false, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(reqBody))
+	req.ContentLength = int64(len(reqBody))
+	return stream, nil
+}
+
+// see https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html
+func signRequest(accessID, secretKey, token, service, region string, req *http.Request) error {
+	signer := v4.NewSigner()
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	sha := sha256.New()
+	_, err = sha.Write(bodyBytes)
+	if err != nil {
+		return err
+	}
+	payloadHash := hex.EncodeToString(sha.Sum(nil))
+
+	err = signer.SignHTTP(
+		req.Context(),
+		aws.Credentials{AccessKeyID: accessID, SecretAccessKey: secretKey, SessionToken: token},
+		req,
+		payloadHash,
+		service,
+		region,
+		time.Now(),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func getUrl(platform string, awsRegion string, model string, stream bool) string {
+	endpoint := map[string]map[bool]string{
+		"bedrock":   {true: "invoke-with-response-stream", false: "invoke"},
+		"sagemaker": {true: "invocations-response-stream", false: "invocations"},
+	}
+	return fmt.Sprintf("https://%s-runtime.%s.amazonaws.com/model/%s/%s", platform, awsRegion, model, endpoint[platform][stream])
+}
+
+func NewBedrockClient(baseOpts []option.RequestOption, awsOpts []AwsRequestOption) *Client {
+	return NewAwsClient(baseOpts, awsOpts, "bedrock")
+}
+
+func NewSagemakerClient(baseOpts []option.RequestOption, awsOpts []AwsRequestOption) *Client {
+	return NewAwsClient(baseOpts, awsOpts, "sagemaker")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/cohere-ai/cohere-go/v2
 go 1.18
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.28.0
 	github.com/google/uuid v1.4.0
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
+	github.com/aws/smithy-go v1.20.2 // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/aws/aws-sdk-go-v2 v1.28.0 h1:ne6ftNhY0lUvlazMUQF15FF6NH80wKmPRFG7g2q6TCw=
+github.com/aws/aws-sdk-go-v2 v1.28.0/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
+github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=

--- a/tests/aws_test.go
+++ b/tests/aws_test.go
@@ -26,6 +26,7 @@ func Generate(t *testing.T, model *string, client client.Client) {
 }
 
 func GenerateStream(t *testing.T, model *string, client client.Client) {
+	t.Skip("Skip until auth is set up")
 	stream, err := client.GenerateStream(
 		context.TODO(),
 		&cohere.GenerateStreamRequest{
@@ -57,6 +58,7 @@ func GenerateStream(t *testing.T, model *string, client client.Client) {
 
 // Test Chat
 func Chat(t *testing.T, model *string, client client.Client) {
+	t.Skip("Skip until auth is set up")
 	chat, err := client.Chat(
 		context.TODO(),
 		&cohere.ChatRequest{
@@ -75,6 +77,7 @@ func Chat(t *testing.T, model *string, client client.Client) {
 
 // Test ChatStream
 func ChatStream(t *testing.T, model *string, client client.Client) {
+	t.Skip("Skip until auth is set up")
 	stream, err := client.ChatStream(
 		context.TODO(),
 		&cohere.ChatStreamRequest{
@@ -116,6 +119,7 @@ func ChatStream(t *testing.T, model *string, client client.Client) {
 }
 
 func Rerank(t *testing.T, model *string, client client.Client) {
+	t.Skip("Skip until auth is set up")
 	rerank, err := client.Rerank(
 		context.TODO(),
 		&cohere.RerankRequest{
@@ -134,6 +138,7 @@ func Rerank(t *testing.T, model *string, client client.Client) {
 }
 
 func Embed(t *testing.T, model *string, client client.Client) {
+	t.Skip("Skip until auth is set up")
 	embed, err := client.Embed(
 		context.TODO(),
 		&cohere.EmbedRequest{
@@ -147,6 +152,7 @@ func Embed(t *testing.T, model *string, client client.Client) {
 }
 
 func Tool(t *testing.T, model *string, client client.Client) {
+	t.Skip("Skip until auth is set up")
 	tools := []*cohere.Tool{
 		{
 			Name:        "sales_database",
@@ -228,6 +234,7 @@ func Tool(t *testing.T, model *string, client client.Client) {
 }
 
 func TestNewAwsClient(t *testing.T) {
+	t.Skip("Skip until auth is set up")
 	bedrockClient := client.NewBedrockClient([]core.RequestOption{}, []client.AwsRequestOption{
 		client.WithAwsRegion("us-east-1"),
 		client.WithAwsAccessKey(""),

--- a/tests/aws_test.go
+++ b/tests/aws_test.go
@@ -1,0 +1,276 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	cohere "github.com/cohere-ai/cohere-go/v2"
+	client "github.com/cohere-ai/cohere-go/v2/client"
+	"github.com/cohere-ai/cohere-go/v2/core"
+	"github.com/stretchr/testify/require"
+)
+
+func Generate(t *testing.T, model *string, client client.Client) {
+	prediction, err := client.Generate(
+		context.TODO(),
+		&cohere.GenerateRequest{
+			Model:  model,
+			Prompt: "count with me!",
+		},
+	)
+
+	require.NoError(t, err)
+	print(prediction)
+}
+
+func GenerateStream(t *testing.T, model *string, client client.Client) {
+	stream, err := client.GenerateStream(
+		context.TODO(),
+		&cohere.GenerateStreamRequest{
+			Model:  model,
+			Prompt: "Cohere is",
+		},
+	)
+
+	require.NoError(t, err)
+
+	// Make sure to close the stream when you're done reading.
+	// This is easily handled with defer.
+	defer stream.Close()
+
+	for {
+		message, err := stream.Recv()
+
+		if errors.Is(err, io.EOF) {
+			// An io.EOF error means the server is done sending messages
+			// and should be treated as a success.
+			break
+		}
+
+		if message.TextGeneration != nil {
+			print(message.TextGeneration.Text)
+		}
+	}
+}
+
+// Test Chat
+func Chat(t *testing.T, model *string, client client.Client) {
+	chat, err := client.Chat(
+		context.TODO(),
+		&cohere.ChatRequest{
+			Model:   model,
+			Message: "2",
+		},
+	)
+
+	require.NotEmpty(t, chat.Text)
+	require.NotEmpty(t, chat.GenerationId)
+	require.NotEmpty(t, chat.FinishReason)
+
+	require.NoError(t, err)
+	print(chat)
+}
+
+// Test ChatStream
+func ChatStream(t *testing.T, model *string, client client.Client) {
+	stream, err := client.ChatStream(
+		context.TODO(),
+		&cohere.ChatStreamRequest{
+			Model:   model,
+			Message: "Cohere is",
+		},
+	)
+
+	typeSet := make(map[string]bool)
+
+	require.NoError(t, err)
+
+	// Make sure to close the stream when you're done reading.
+	// This is easily handled with defer.
+	defer stream.Close()
+
+	for {
+		message, err := stream.Recv()
+
+		if errors.Is(err, io.EOF) {
+			// An io.EOF error means the server is done sending messages
+			// and should be treated as a success.
+			break
+		}
+
+		typeSet[message.EventType] = true
+
+		if message.TextGeneration != nil {
+			// print(message.TextGeneration.Text)
+			require.NotEmpty(t, message.TextGeneration.Text)
+		} else if message.StreamEnd != nil {
+			require.NotEmpty(t, message.StreamEnd.FinishReason)
+			require.NotEmpty(t, message.StreamEnd.Response.Text)
+		}
+	}
+
+	require.Contains(t, typeSet, "text-generation")
+	require.Contains(t, typeSet, "stream-end")
+}
+
+func Rerank(t *testing.T, model *string, client client.Client) {
+	rerank, err := client.Rerank(
+		context.TODO(),
+		&cohere.RerankRequest{
+			Model: model,
+			Query: "What is the capital of the United States?",
+			Documents: []*cohere.RerankRequestDocumentsItem{
+				{String: "Carson City is the capital city of the American state of Nevada."},
+				{String: "The Commonwealth of the Northern Mariana Islands is a group of islands in the Pacific Ocean. Its capital is Saipan."},
+				{String: "Washington, D.C. (also known as simply Washington or D.C., and officially as the District of Columbia) is the capital of the United States. It is a federal district."},
+				{String: "Capital punishment (the death penalty) has existed in the United States since beforethe United States was a country. As of 2017, capital punishment is legal in 30 of the 50 states."},
+			},
+		})
+
+	require.NoError(t, err)
+	print(rerank)
+}
+
+func Embed(t *testing.T, model *string, client client.Client) {
+	embed, err := client.Embed(
+		context.TODO(),
+		&cohere.EmbedRequest{
+			Model:     model,
+			Texts:     []string{"hello", "goodbye"},
+			InputType: cohere.EmbedInputTypeSearchDocument.Ptr(),
+		})
+
+	require.NoError(t, err)
+	print(embed)
+}
+
+func Tool(t *testing.T, model *string, client client.Client) {
+	tools := []*cohere.Tool{
+		{
+			Name:        "sales_database",
+			Description: "Connects to a database about sales volumes",
+			ParameterDefinitions: map[string]*cohere.ToolParameterDefinitionsValue{
+				"day": {
+					Description: cohere.String("Retrieves sales data from this day, formatted as YYYY-MM-DD."),
+					Type:        "str",
+					Required:    cohere.Bool(true),
+				},
+			},
+		},
+	}
+
+	toolsResponse, err := client.Chat(
+		context.TODO(),
+		&cohere.ChatRequest{
+			Model:   model,
+			Message: "How good were the sales on September 29?",
+			Tools:   tools,
+			Preamble: cohere.String(`
+				## Task Description
+				You help people answer their questions and other requests interactively. You will be asked a very wide array of requests on all kinds of topics. You will be equipped with a wide range of search engines or similar tools to help you, which you use to research your answer. You should focus on serving the user's needs as best you can, which will be wide-ranging.
+
+				## Style Guide
+				Unless the user asks for a different style of answer, you should answer in full sentences, using proper grammar and spelling.
+			`),
+			ForceSingleStep: cohere.Bool(true),
+		})
+
+	require.NoError(t, err)
+	require.NotNil(t, toolsResponse.ToolCalls)
+	require.Len(t, toolsResponse.ToolCalls, 1)
+	require.Equal(t, toolsResponse.ToolCalls[0].Name, "sales_database")
+	require.Equal(t, toolsResponse.ToolCalls[0].Parameters["day"], "2023-09-29")
+
+	print(toolsResponse)
+
+	localTools := map[string]func(string) *[]map[string]interface{}{
+		"sales_database": func(day string) *[]map[string]interface{} {
+			return &[]map[string]interface{}{
+				{
+					"numberOfSales":    120,
+					"totalRevenue":     48500,
+					"averageSaleValue": 404.17,
+					"date":             "2023-09-29",
+				},
+			}
+		},
+	}
+
+	toolResults := make([]*cohere.ToolResult, 0)
+
+	for _, toolCall := range toolsResponse.ToolCalls {
+		result := localTools[toolCall.Name](toolCall.Parameters["day"].(string))
+		toolResult := &cohere.ToolResult{
+			Call:    toolCall,
+			Outputs: *result,
+		}
+		toolResults = append(toolResults, toolResult)
+	}
+
+	citedResponse, err := client.Chat(
+		context.TODO(),
+		&cohere.ChatRequest{
+			Model:           model,
+			Message:         "How good were the sales on September 29?",
+			Tools:           tools,
+			ToolResults:     toolResults,
+			ForceSingleStep: cohere.Bool(true),
+		})
+
+	require.NoError(t, err)
+
+	require.Equal(t, citedResponse.Documents[0]["averageSaleValue"], "404.17")
+	require.Equal(t, citedResponse.Documents[0]["date"], "2023-09-29")
+	require.Equal(t, citedResponse.Documents[0]["numberOfSales"], "120")
+	require.Equal(t, citedResponse.Documents[0]["totalRevenue"], "48500")
+}
+
+func TestNewAwsClient(t *testing.T) {
+	bedrockClient := client.NewBedrockClient([]core.RequestOption{}, []client.AwsRequestOption{
+		client.WithAwsRegion("us-east-1"),
+		client.WithAwsAccessKey(""),
+		client.WithAwsSecretKey(""),
+		client.WithAwsSessionToken(""),
+	})
+
+	bedrockModels := map[string]*string{
+		"generate": cohere.String("cohere.command-text-v14"),
+		"embed":    cohere.String("cohere.embed-multilingual-v3"),
+		"chat":     cohere.String("cohere.command-r-plus-v1:0"),
+	}
+
+	sagemakerClent := client.NewSagemakerClient([]core.RequestOption{}, []client.AwsRequestOption{
+		client.WithAwsRegion("us-east-1"),
+		client.WithAwsAccessKey(""),
+		client.WithAwsSecretKey(""),
+		client.WithAwsSessionToken(""),
+	})
+
+	sagemakerModels := map[string]*string{
+		"generate": cohere.String("cohere-command-light"),
+		"embed":    cohere.String("cohere-embed-multilingual-v3"),
+		"chat":     cohere.String("cohere-command-plus"),
+		"rerank":   cohere.String("cohere-rerank"),
+	}
+
+	t.Run("Bedrock tests", func(t *testing.T) {
+		t.Run("Generate", func(t *testing.T) { Generate(t, bedrockModels["generate"], *bedrockClient) })
+		t.Run("GenerateStream", func(t *testing.T) { GenerateStream(t, bedrockModels["generate"], *bedrockClient) })
+		t.Run("Chat", func(t *testing.T) { Chat(t, bedrockModels["chat"], *bedrockClient) })
+		t.Run("ChatStream", func(t *testing.T) { ChatStream(t, bedrockModels["chat"], *bedrockClient) })
+		t.Run("Embed", func(t *testing.T) { Embed(t, bedrockModels["embed"], *bedrockClient) })
+		t.Run("Tool", func(t *testing.T) { Tool(t, bedrockModels["chat"], *bedrockClient) })
+	})
+
+	t.Run("Sagemaker tests", func(t *testing.T) {
+		t.Run("Generate", func(t *testing.T) { Generate(t, sagemakerModels["generate"], *sagemakerClent) })
+		t.Run("GenerateStream", func(t *testing.T) { GenerateStream(t, sagemakerModels["generate"], *sagemakerClent) })
+		t.Run("Chat", func(t *testing.T) { Chat(t, sagemakerModels["chat"], *sagemakerClent) })
+		t.Run("ChatStream", func(t *testing.T) { ChatStream(t, sagemakerModels["chat"], *sagemakerClent) })
+		t.Run("Rerank", func(t *testing.T) { Rerank(t, sagemakerModels["rerank"], *sagemakerClent) })
+		t.Run("Embed", func(t *testing.T) { Embed(t, sagemakerModels["embed"], *sagemakerClent) })
+		t.Run("Tool", func(t *testing.T) { Tool(t, sagemakerModels["chat"], *sagemakerClent) })
+	})
+}

--- a/tests/sdk_test.go
+++ b/tests/sdk_test.go
@@ -22,14 +22,6 @@ func (m *MyReader) Name() string {
 	return m.name
 }
 
-func strPointer(s string) *string {
-	return &s
-}
-
-func boolPointer(s bool) *bool {
-	return &s
-}
-
 func TestNewClient(t *testing.T) {
 	client := client.NewClient(client.WithToken(os.Getenv("COHERE_API_KEY")))
 
@@ -123,20 +115,20 @@ func TestNewClient(t *testing.T) {
 			&cohere.ClassifyRequest{
 				Examples: []*cohere.ClassifyExample{
 					{
-						Text:  strPointer("orange"),
-						Label: strPointer("fruit"),
+						Text:  cohere.String("orange"),
+						Label: cohere.String("fruit"),
 					},
 					{
-						Text:  strPointer("pear"),
-						Label: strPointer("fruit"),
+						Text:  cohere.String("pear"),
+						Label: cohere.String("fruit"),
 					},
 					{
-						Text:  strPointer("lettuce"),
-						Label: strPointer("vegetable"),
+						Text:  cohere.String("lettuce"),
+						Label: cohere.String("vegetable"),
 					},
 					{
-						Text:  strPointer("cauliflower"),
-						Label: strPointer("vegetable"),
+						Text:  cohere.String("cauliflower"),
+						Label: cohere.String("vegetable"),
 					},
 				},
 				Inputs: []string{"Abiu"},
@@ -206,7 +198,7 @@ func TestNewClient(t *testing.T) {
 			context.TODO(),
 			&cohere.EmbedRequest{
 				Texts:     []string{"hello", "goodbye"},
-				Model:     strPointer("embed-english-v3.0"),
+				Model:     cohere.String("embed-english-v3.0"),
 				InputType: cohere.EmbedInputTypeSearchDocument.Ptr(),
 			})
 
@@ -315,7 +307,7 @@ func TestNewClient(t *testing.T) {
 			context.TODO(),
 			connector.Connector.Id,
 			&cohere.UpdateConnectorRequest{
-				Name: strPointer("Example connector renamed"),
+				Name: cohere.String("Example connector renamed"),
 			})
 
 		require.NoError(t, err)
@@ -337,7 +329,7 @@ func TestNewClient(t *testing.T) {
 			context.TODO(),
 			connector.Connector.Id,
 			&cohere.ConnectorsOAuthAuthorizeRequest{
-				AfterTokenRedirect: strPointer("https://test.com"),
+				AfterTokenRedirect: cohere.String("https://test.com"),
 			})
 
 		// find a way to test this
@@ -357,9 +349,9 @@ func TestNewClient(t *testing.T) {
 				Description: "Connects to a database about sales volumes",
 				ParameterDefinitions: map[string]*cohere.ToolParameterDefinitionsValue{
 					"day": {
-						Description: strPointer("Retrieves sales data from this day, formatted as YYYY-MM-DD."),
+						Description: cohere.String("Retrieves sales data from this day, formatted as YYYY-MM-DD."),
 						Type:        "str",
-						Required:    boolPointer(true),
+						Required:    cohere.Bool(true),
 					},
 				},
 			},
@@ -370,7 +362,7 @@ func TestNewClient(t *testing.T) {
 			&cohere.ChatRequest{
 				Message: "How good were the sales on September 29?",
 				Tools:   tools,
-				Preamble: strPointer(`
+				Preamble: cohere.String(`
 					## Task Description
 					You help people answer their questions and other requests interactively. You will be asked a very wide array of requests on all kinds of topics. You will be equipped with a wide range of search engines or similar tools to help you, which you use to research your answer. You should focus on serving the user's needs as best you can, which will be wide-ranging.
 
@@ -418,7 +410,7 @@ func TestNewClient(t *testing.T) {
 				Message:         "How good were the sales on September 29?",
 				Tools:           tools,
 				ToolResults:     toolResults,
-				Model:           strPointer("command-nightly"),
+				Model:           cohere.String("command-nightly"),
 				ForceSingleStep: cohere.Bool(true),
 			})
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR introduces a new AWS client and its associated tests.

**New files:**
- `client/aws.go`
- `tests/aws_test.go`

**Changes:**
- Added `client/aws.go` to `.fernignore`
- Updated `go.mod` and `go.sum` to include the new dependencies
- Replaced `*string` with `cohere.String` in `tests/sdk_test.go`

**New AWS Client:**
The new AWS client, `awsClient`, is designed to interact with AWS services. It uses the `aws-sdk-go-v2` package to make requests to AWS. The client supports various options, such as specifying the AWS region, access key, secret key, and session token. It provides methods for making HTTP requests, signing requests, and handling responses.

**Tests:**
The `tests/aws_test.go` file contains tests for the new AWS client. It includes tests for different AWS services, such as Bedrock and Sagemaker. The tests cover various functionalities, including generating requests, streaming, chatting, embedding, and using tools.

<!-- end-generated-description -->