### PR TITLE
Fix sagemaker url

### DIFF
--- a/client/aws.go
+++ b/client/aws.go
@@ -246,7 +246,19 @@ func getUrl(platform string, awsRegion string, model string, stream bool) string
 		"bedrock":   {true: "invoke-with-response-stream", false: "invoke"},
 		"sagemaker": {true: "invocations-response-stream", false: "invocations"},
 	}
-	return fmt.Sprintf("https://%s-runtime.%s.amazonaws.com/model/%s/%s", platform, awsRegion, model, endpoint[platform][stream])
+
+	if platformEndpoints, ok := endpoint[platform]; ok {
+		if endpointValue, ok := platformEndpoints[stream]; ok {
+			switch platform {
+			case "bedrock":
+				return fmt.Sprintf("https://%s-runtime.%s.amazonaws.com/model/%s/%s", platform, awsRegion, model, endpointValue)
+			case "sagemaker":
+				return fmt.Sprintf("https://runtime.sagemaker.%s.amazonaws.com/endpoints/%s/%s", awsRegion, model, endpointValue)
+			}
+		}
+	}
+
+	return ""
 }
 
 func NewBedrockClient(baseOpts []option.RequestOption, awsOpts []AwsRequestOption) *Client {


### PR DESCRIPTION
<!-- begin-generated-description -->

## Description
This PR updates the `getUrl` function in the `client/aws.go` file. The function now includes a check to ensure that the `platform` and `stream` values exist in the `endpoint` map before constructing the URL. If the values are not found, the function returns an empty string.

## Changes
- The function now checks if the `platform` exists in the `endpoint` map using a type assertion.
- If the `platform` exists, it then checks if the `stream` value exists in the corresponding map.
- If both values exist, the function constructs the URL based on the `platform` value.
- If the `platform` is `"bedrock"`, the function uses the original URL format.
- If the `platform` is `"sagemaker"`, the function uses a different URL format.
- If either the `platform` or `stream` value does not exist, the function returns an empty string.

**Code Changes**
- Added a type assertion to check if the `platform` exists in the `endpoint` map.
- Added a nested type assertion to check if the `stream` value exists in the corresponding map.
- Added a `switch` statement to construct the URL based on the `platform` value.
- Added a `return` statement to return an empty string if either the `platform` or `stream` value does not exist.
- Removed the original `return` statement that constructed the URL without checking for the existence of the `platform` and `stream` values.

<!-- end-generated-description -->