### PR TITLE
chore: update ci. remove connectors & summarize tests

### DIFF
--- a/tests/sdk_test.go
+++ b/tests/sdk_test.go
@@ -116,7 +116,7 @@ func TestNewClient(t *testing.T) {
 			context.TODO(),
 			&cohere.TokenizeRequest{
 				Text:  str,
-				Model: "base",
+				Model: "command-a-03-2025",
 			},
 		)
 
@@ -126,6 +126,7 @@ func TestNewClient(t *testing.T) {
 		detokenise, err := client.Detokenize(
 			context.TODO(),
 			&cohere.DetokenizeRequest{
+				Model:  "command-a-03-2025",
 				Tokens: tokenise.Tokens,
 			})
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the `TestNewClient` function in the `sdk_test.go` file, replacing the `base` model with the `command-a-03-2025` model in the `TokenizeRequest` and adding the same model to the `DetokenizeRequest`. It also removes the `TestSummarize` and `TestConnectorCRUD` test cases.

- The `Model` field in the `TokenizeRequest` is updated from `"base"` to `"command-a-03-2025"`.
- A new `Model` field is added to the `DetokenizeRequest` with the value `"command-a-03-2025"`.
- The `TestSummarize` test case is removed.
- The `TestConnectorCRUD` test case is removed.

<!-- end-generated-description -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that remove coverage for two endpoints and update a model string; no production logic is affected.
> 
> **Overview**
> Updates the SDK integration tests by switching the tokenize/detokenize coverage to use `command-a-03-2025` and explicitly passing the model for detokenization.
> 
> Removes the `TestSummarize` and `TestConnectorCRUD` subtests from `tests/sdk_test.go`, reducing CI reliance on endpoints that are flaky or hard to exercise in test runs (e.g., OAuth/connector lifecycle).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d73724ceba3e30b092e36d5c83c752b206a5fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->